### PR TITLE
PMO puzzles for GhClose and GhUpdate, commit returns a repo

### DIFF
--- a/src/main/java/git/tracehub/agents/github/Commit.java
+++ b/src/main/java/git/tracehub/agents/github/Commit.java
@@ -23,10 +23,12 @@
  */
 package git.tracehub.agents.github;
 
+import java.net.URI;
 import java.util.List;
 import javax.json.JsonValue;
 import lombok.RequiredArgsConstructor;
 import org.cactoos.list.ListOf;
+import org.cactoos.text.Joined;
 
 /**
  * Commit on GitHub.
@@ -34,6 +36,14 @@ import org.cactoos.list.ListOf;
  * @since 0.0.0
  */
 public interface Commit {
+
+    /**
+     * Repository name.
+     *
+     * @return Repo name as a string
+     * @throws Exception if something went wrong
+     */
+    String repo() throws Exception;
 
     /**
      * Created files.
@@ -68,6 +78,15 @@ public interface Commit {
          * Commit.
          */
         private final JsonValue commit;
+
+        @Override
+        public String repo() throws Exception {
+            final String[] split = new URI(
+                this.commit.asJsonObject().getString("url")
+            ).getPath().split("/");
+            return new Joined("/", new ListOf<>(split[1], split[2]))
+                .asString();
+        }
 
         @Override
         public List<String> created() {

--- a/src/main/java/git/tracehub/agents/github/Composed.java
+++ b/src/main/java/git/tracehub/agents/github/Composed.java
@@ -52,6 +52,11 @@ public final class Composed implements Commit {
     }
 
     @Override
+    public String repo() throws Exception {
+        return this.chain.get(0).repo();
+    }
+
+    @Override
     @SneakyThrows
     public List<String> created() {
         return this.merge().get("created");

--- a/src/main/java/git/tracehub/agents/github/ThJobs.java
+++ b/src/main/java/git/tracehub/agents/github/ThJobs.java
@@ -46,6 +46,11 @@ public final class ThJobs implements Commit {
     private final Commit origin;
 
     @Override
+    public String repo() throws Exception {
+        return this.origin.repo();
+    }
+
+    @Override
     public List<String> created() {
         return this.origin.created().stream()
             .filter(name -> ThJobs.PATTERN.matcher(name).matches())

--- a/src/main/java/git/tracehub/agents/github/TraceLogged.java
+++ b/src/main/java/git/tracehub/agents/github/TraceLogged.java
@@ -41,6 +41,11 @@ public final class TraceLogged implements Commit {
     private final Commit origin;
 
     @Override
+    public String repo() throws Exception {
+        return this.origin.repo();
+    }
+
+    @Override
     public List<String> created() {
         final List<String> created = this.origin.created();
         if (!created.isEmpty()) {

--- a/src/main/java/git/tracehub/agents/github/TraceOnly.java
+++ b/src/main/java/git/tracehub/agents/github/TraceOnly.java
@@ -46,6 +46,11 @@ public final class TraceOnly implements Commit {
     private final Commit origin;
 
     @Override
+    public String repo() throws Exception {
+        return this.origin.repo();
+    }
+
+    @Override
     public List<String> created() {
         return this.origin.created().stream()
             .filter(name -> TraceOnly.PATTERN.matcher(name).matches())

--- a/src/main/java/git/tracehub/agents/github/issues/GhNew.java
+++ b/src/main/java/git/tracehub/agents/github/issues/GhNew.java
@@ -39,6 +39,23 @@ import org.cactoos.text.TextOf;
  * New GitHub issues.
  *
  * @since 0.0.0
+ * @todo #28:60min Submit created tickets to a PMO.
+ *  We should submit it directly to a PMO on each issue we created.
+ *  Probably an input will be an issue number, repo, and full file path.
+ *  For now can be postponed. We should prepare PMO for that firstly.
+ *  Don't forget to remove this puzzle.
+ * @todo #28:60min Implement GhClose.java.
+ *  We should implement a logic for closing a GitHub issue
+ *  for each deleted file in ThJobs#deleted().
+ *  As described above we need to reach out to PMO.
+ *  PMO will provide us the issue number by the full path of deleted job.
+ *  We should get the issue and close it in GitHub.
+ *  Don't forget to remove this puzzle.
+ * @todo #28:60min Implement GhUpdate.java.
+ *  We should implement a logic for updating for each updated files in ThJobs#updated().
+ *  We provide a full path of updated job to PMO, PMO gets us an issue number.
+ *  From there, probably we should post a comment to that issue that things gets
+ *  an update.
  */
 @RequiredArgsConstructor
 public final class GhNew implements Scalar<List<Issue>> {

--- a/src/test/java/git/tracehub/agents/github/CommitTest.java
+++ b/src/test/java/git/tracehub/agents/github/CommitTest.java
@@ -165,4 +165,27 @@ final class CommitTest {
             )
         );
     }
+
+    @Test
+    void returnsRepo() throws Exception {
+        final List<Commit> commits = new GhCommits(
+            new RqFake(
+                "POST",
+                "",
+                new Jocument(
+                    new JsonOf(
+                        new ResourceOf("github/hooks/many-commits.json").stream()
+                    )
+                ).pretty()
+            )
+        ).value();
+        final String repo = commits.get(0).repo();
+        final String expected = "tracehubpm/tracehub";
+        MatcherAssert.assertThat(
+            "Repo name %s does not match with expected %s"
+                .formatted(repo, expected),
+            repo,
+            new IsEqual<>(expected)
+        );
+    }
 }

--- a/src/test/java/git/tracehub/agents/github/ComposedTest.java
+++ b/src/test/java/git/tracehub/agents/github/ComposedTest.java
@@ -173,4 +173,29 @@ final class ComposedTest {
             )
         );
     }
+
+    @Test
+    void returnsRepo() throws Exception {
+        final Commit composed = new Composed(
+            new GhCommits(
+                new RqFake(
+                    "POST",
+                    "",
+                    new Jocument(
+                        new JsonOf(
+                            new ResourceOf("github/hooks/more-duplicates.json").stream()
+                        )
+                    ).pretty()
+                )
+            )
+        );
+        final String repo = composed.repo();
+        final String expected = "tracehubpm/tracehub";
+        MatcherAssert.assertThat(
+            "Repo name %s does not match with expected %s"
+                .formatted(repo, expected),
+            repo,
+            new IsEqual<>(expected)
+        );
+    }
 }

--- a/src/test/java/git/tracehub/agents/github/ThJobsTest.java
+++ b/src/test/java/git/tracehub/agents/github/ThJobsTest.java
@@ -90,4 +90,38 @@ final class ThJobsTest {
             )
         );
     }
+
+    @Test
+    void returnsRepo() throws Exception {
+        final Commit commit =
+            new ThJobs(
+                new TraceLogged(
+                    new TraceOnly(
+                        new Composed(
+                            new GhCommits(
+                                new RqFake(
+                                    "POST",
+                                    "",
+                                    new Jocument(
+                                        new JsonOf(
+                                            new ResourceOf(
+                                                "github/hooks/more-duplicates.json"
+                                            ).stream()
+                                        )
+                                    ).pretty()
+                                )
+                            )
+                        )
+                    )
+                )
+            );
+        final String repo = commit.repo();
+        final String expected = "tracehubpm/tracehub";
+        MatcherAssert.assertThat(
+            "Repo name %s does not match with expected %s"
+                .formatted(repo, expected),
+            repo,
+            new IsEqual<>(expected)
+        );
+    }
 }

--- a/src/test/java/git/tracehub/agents/github/TraceLoggedTest.java
+++ b/src/test/java/git/tracehub/agents/github/TraceLoggedTest.java
@@ -79,4 +79,35 @@ final class TraceLoggedTest {
             )
         );
     }
+
+    @Test
+    void returnsRepo() throws Exception {
+        final Commit commit = new TraceLogged(
+            new TraceOnly(
+                new Composed(
+                    new GhCommits(
+                        new RqFake(
+                            "POST",
+                            "",
+                            new Jocument(
+                                new JsonOf(
+                                    new ResourceOf(
+                                        "github/hooks/more-duplicates.json"
+                                    ).stream()
+                                )
+                            ).pretty()
+                        )
+                    )
+                )
+            )
+        );
+        final String repo = commit.repo();
+        final String expected = "tracehubpm/tracehub";
+        MatcherAssert.assertThat(
+            "Repo name %s does not match with expected %s"
+                .formatted(repo, expected),
+            repo,
+            new IsEqual<>(expected)
+        );
+    }
 }

--- a/src/test/java/git/tracehub/agents/github/TraceOnlyTest.java
+++ b/src/test/java/git/tracehub/agents/github/TraceOnlyTest.java
@@ -85,4 +85,33 @@ final class TraceOnlyTest {
             new IsEqual<>(true)
         );
     }
+
+    @Test
+    void returnsRepo() throws Exception {
+        final Commit commit = new TraceOnly(
+            new Composed(
+                new GhCommits(
+                    new RqFake(
+                        "POST",
+                        "",
+                        new Jocument(
+                            new JsonOf(
+                                new ResourceOf(
+                                    "github/hooks/many-commits.json"
+                                ).stream()
+                            )
+                        ).pretty()
+                    )
+                )
+            )
+        );
+        final String repo = commit.repo();
+        final String expected = "tracehubpm/tracehub";
+        MatcherAssert.assertThat(
+            "Repo name %s does not match with expected %s"
+                .formatted(repo, expected),
+            repo,
+            new IsEqual<>(expected)
+        );
+    }
 }


### PR DESCRIPTION
closes #28 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a `repo()` method to the `Commit` interface and implementing it in the `Smart` class. 

### Detailed summary
- Added `repo()` method to `Commit` interface
- Implemented `repo()` method in `Smart` class to extract repository name from commit URL

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->