### PR TITLE
JaCoCo tresholds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -317,32 +317,32 @@ SOFTWARE.
                     <limit>
                       <counter>INSTRUCTION</counter>
                       <value>COVEREDRATIO</value>
-                      <minimum>0.00</minimum>
+                      <minimum>0.69</minimum>
                     </limit>
                     <limit>
                       <counter>LINE</counter>
                       <value>COVEREDRATIO</value>
-                      <minimum>0.00</minimum>
+                      <minimum>0.65</minimum>
                     </limit>
                     <limit>
                       <counter>BRANCH</counter>
                       <value>COVEREDRATIO</value>
-                      <minimum>0.00</minimum>
+                      <minimum>0.65</minimum>
                     </limit>
                     <limit>
                       <counter>COMPLEXITY</counter>
                       <value>COVEREDRATIO</value>
-                      <minimum>0.00</minimum>
+                      <minimum>0.65</minimum>
                     </limit>
                     <limit>
                       <counter>METHOD</counter>
                       <value>COVEREDRATIO</value>
-                      <minimum>0.00</minimum>
+                      <minimum>0.65</minimum>
                     </limit>
                     <limit>
                       <counter>CLASS</counter>
                       <value>MISSEDCOUNT</value>
-                      <maximum>30</maximum>
+                      <maximum>10</maximum>
                     </limit>
                   </limits>
                 </rule>


### PR DESCRIPTION
closes #40 

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- The focus of this PR is to update the minimum coverage ratios for different code metrics in the `pom.xml` file.
- The minimum coverage ratios for `INSTRUCTION`, `LINE`, `BRANCH`, `COMPLEXITY`, and `METHOD` counters have been increased from 0.00 to 0.65.
- The maximum missed count for the `CLASS` counter has been decreased from 30 to 10.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->