### PR TITLE
simulation to mvn

### DIFF
--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -13,15 +13,13 @@ concurrency:
   group: mvn-${{ github.ref }}
   cancel-in-progress: true
 jobs:
-  mvn:
-    name: mvn
+  test:
+    name: test
     strategy:
       matrix:
         os: [ ubuntu-20.04 ]
         java: [ 17 ]
     runs-on: ${{ matrix.os }}
-    env:
-      CONVERT_PATH: /tmp/antlr4-to-bnf-converter
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - uses: actions/setup-java@v4
@@ -34,3 +32,22 @@ jobs:
           key: ${{ runner.os }}-jdk-${{ matrix.java }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-jdk-${{ matrix.java }}-maven-
       - run: mvn clean install -Pjacoco --errors --batch-mode
+  simulation:
+    name: simulation tests
+    strategy:
+      matrix:
+        os: [ ubuntu-20.04 ]
+        java: [ 17 ]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.java }}
+      - uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-jdk-${{ matrix.java }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-jdk-${{ matrix.java }}-maven-
+      - run: mvn clean install -Psimulation -DTracehub-GitHubToken=${{ secrets.TRACEHUBTOKEN }} --errors -Dstyle.color=never


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on adding a new job called "simulation" to the existing GitHub Actions workflow. 

### Detailed summary:
- Renamed the existing job "mvn" to "test".
- Added a new job called "simulation" for running simulation tests.
- Updated the strategy matrix for both jobs to use Ubuntu 20.04 and Java 17.
- Added steps to checkout the code, set up Java, and cache the Maven repository for both jobs.
- Modified the command for the "test" job to run "mvn clean install -Pjacoco --errors --batch-mode".
- Added a new command for the "simulation" job to run "mvn clean install -Psimulation -DTracehub-GitHubToken=${{ secrets.TRACEHUBTOKEN }} --errors -Dstyle.color=never".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->