### PR TITLE
chore(#113): JoinedErrorsTest

### DIFF
--- a/src/test/java/git/tracehub/validation/JoinedErrorsTest.java
+++ b/src/test/java/git/tracehub/validation/JoinedErrorsTest.java
@@ -1,0 +1,54 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023-2024 Tracehub.git
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package git.tracehub.validation;
+
+import org.cactoos.list.ListOf;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link JoinedErrors}.
+ *
+ * @since 0.0.0
+ */
+final class JoinedErrorsTest {
+
+    @Test
+    void returnsJoinedErrors() throws Exception {
+        final String text = new JoinedErrors(
+            () -> new ListOf<>(
+                "some error #1",
+                "some error #2"
+            )
+        ).asString();
+        final String expected = "some error #1\nsome error #2";
+        MatcherAssert.assertThat(
+            "Joined text %s does not match with expected %s"
+                .formatted(text, expected),
+            text,
+            new IsEqual<>(expected)
+        );
+    }
+}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a test case for the `JoinedErrors` class in the `JoinedErrorsTest` file.

### Detailed summary
- Added a test case for the `JoinedErrors` class.
- The test case checks if the joined errors match the expected output.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->